### PR TITLE
feat: adjust cycle probability

### DIFF
--- a/lottery_prediction/tests/test_frequency_analysis_service.py
+++ b/lottery_prediction/tests/test_frequency_analysis_service.py
@@ -1,0 +1,33 @@
+import pytest
+from datetime import date, timedelta
+
+from results.models import NumberFrequencyStats
+from results.services.frequency_analysis_service import get_frequency_analysis_service
+
+
+@pytest.mark.django_db
+def test_probability_reduced_without_consecutive():
+    analysis_date = date(2023, 1, 10)
+    number = "12"
+
+    for offset in [1, 4, 7]:
+        dt = analysis_date - timedelta(days=offset)
+        NumberFrequencyStats.objects.create(
+            number=number,
+            date=dt,
+            appeared_in_special=False,
+            appeared_in_first=False,
+            appeared_in_other=True,
+            day_of_week=dt.weekday(),
+            day_of_month=dt.day,
+            week_of_month=(dt.day - 1) // 7 + 1,
+            month=dt.month,
+            year=dt.year,
+        )
+
+    service = get_frequency_analysis_service()
+    analysis = service.get_comprehensive_analysis(number, analysis_date=analysis_date)
+
+    assert analysis["gan_analysis"]["current_gan_days"] == 1
+    assert analysis["consecutive_analysis"]["max_consecutive_days"] == 0
+    assert analysis["prediction_probabilities"]["combined"] < 30

--- a/results/services/frequency_analysis_service.py
+++ b/results/services/frequency_analysis_service.py
@@ -340,9 +340,9 @@ class FrequencyAnalysisService:
         gan_analysis = analysis_data['gan_analysis']
         cycle_analysis = analysis_data['cycle_analysis']
         
-        # Probability based on average cycle
+        # Probability based on average cycle (direct proportional formula)
         if cycle_analysis['avg_cycle'] > 0:
-            cycle_probability = max(0, 100 - (gan_analysis['current_gan_days'] / cycle_analysis['avg_cycle'] * 100))
+            cycle_probability = min(100, (gan_analysis['current_gan_days'] / cycle_analysis['avg_cycle']) * 100)
         else:
             cycle_probability = 50
         
@@ -355,6 +355,10 @@ class FrequencyAnalysisService:
         
         # Combined probability (weighted average)
         combined_probability = (cycle_probability * 0.6 + max_gan_probability * 0.4)
+
+        # Reduce probability if number has never appeared on consecutive days
+        if analysis_data.get('consecutive_analysis', {}).get('max_consecutive_days') == 0:
+            combined_probability *= 0.7
         
         return {
             'cycle_based': round(cycle_probability, 2),


### PR DESCRIPTION
## Summary
- use direct proportional formula for cycle-based probability
- lower combined probability when no consecutive appearances
- add regression test for low probability when current_gan_days=1

## Testing
- `pytest lottery_prediction/tests/test_frequency_analysis_service.py -q` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68ae72c6878c832990324800e4e23bfc