### PR TITLE
Optimize frequency analysis queries and index date

### DIFF
--- a/results/migrations/0003_numberfrequencystats_date_index.py
+++ b/results/migrations/0003_numberfrequencystats_date_index.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("results", "0002_frequency_analysis_models"),
+    ]
+
+    operations = [
+        migrations.RemoveIndex(
+            model_name="numberfrequencystats",
+            name="results_num_date_160709_idx",
+        ),
+        migrations.AlterField(
+            model_name="numberfrequencystats",
+            name="date",
+            field=models.DateField(db_index=True, help_text="Ngày xuất hiện"),
+        ),
+    ]

--- a/results/models.py
+++ b/results/models.py
@@ -2502,7 +2502,7 @@ class NumberFrequencyStats(models.Model):
     """Lưu trữ tần suất xuất hiện của các số theo ngày"""
 
     number = models.CharField(max_length=2, help_text="Số 2 chữ số (00-99)")
-    date = models.DateField(help_text="Ngày xuất hiện")
+    date = models.DateField(help_text="Ngày xuất hiện", db_index=True)
 
     # Vị trí xuất hiện (để phân tích theo giải)
     appeared_in_special = models.BooleanField(
@@ -2526,7 +2526,6 @@ class NumberFrequencyStats(models.Model):
         unique_together = ("number", "date")
         indexes = [
             models.Index(fields=["number"]),
-            models.Index(fields=["date"]),
             models.Index(fields=["day_of_month"]),
             models.Index(fields=["month"]),
             models.Index(fields=["year"]),

--- a/results/services/frequency_analysis_service.py
+++ b/results/services/frequency_analysis_service.py
@@ -227,34 +227,36 @@ class FrequencyAnalysisService:
         """Calculate numbers that frequently appear together with the given number"""
         
         # Get dates when this number appeared
-        appearance_dates = NumberFrequencyStats.objects.filter(
-            number=number,
-            date__lte=analysis_date
-        ).values_list('date', flat=True)
-        
-        # Find other numbers that appeared on the same dates
-        companion_counts = defaultdict(int)
-        
-        for appearance_date in appearance_dates:
-            other_numbers = NumberFrequencyStats.objects.filter(
-                date=appearance_date
-            ).exclude(number=number).values_list('number', flat=True)
-            
-            for other_number in other_numbers:
-                companion_counts[other_number] += 1
-        
-        # Sort by frequency and get top 10
-        companions = []
-        for comp_number, count in sorted(companion_counts.items(), key=lambda x: x[1], reverse=True)[:10]:
-            total_appearances = len(appearance_dates)
-            percentage = (count / total_appearances * 100) if total_appearances > 0 else 0
-            
-            companions.append({
-                'number': comp_number,
-                'co_occurrences': count,
-                'percentage': round(percentage, 2)
-            })
-        
+        appearance_dates = list(
+            NumberFrequencyStats.objects.filter(
+                number=number,
+                date__lte=analysis_date
+            ).values_list('date', flat=True)
+        )
+
+        if not appearance_dates:
+            return []
+
+        total_appearances = len(appearance_dates)
+
+        # Query once for all companion numbers and aggregate
+        companion_qs = (
+            NumberFrequencyStats.objects.filter(date__in=appearance_dates)
+            .exclude(number=number)
+            .values('number')
+            .annotate(co_occurrences=Count('id'))
+            .order_by('-co_occurrences')[:10]
+        )
+
+        companions = [
+            {
+                'number': item['number'],
+                'co_occurrences': item['co_occurrences'],
+                'percentage': round(item['co_occurrences'] / total_appearances * 100, 2)
+            }
+            for item in companion_qs
+        ]
+
         return companions
     
     def _calculate_consecutive_analysis(self, frequency_data) -> Dict[str, Any]:
@@ -302,36 +304,35 @@ class FrequencyAnalysisService:
         """Calculate numbers that frequently appear before this number"""
         
         # Get dates when this number appeared
-        appearance_dates = list(NumberFrequencyStats.objects.filter(
-            number=number,
-            date__lte=analysis_date
-        ).values_list('date', flat=True))
-        
-        predecessor_counts = defaultdict(int)
-        
-        for appearance_date in appearance_dates:
-            # Look for numbers that appeared 1 day before
-            previous_date = appearance_date - timedelta(days=1)
-            previous_numbers = NumberFrequencyStats.objects.filter(
-                date=previous_date
-            ).values_list('number', flat=True)
-            
-            for prev_number in previous_numbers:
-                predecessor_counts[prev_number] += 1
-        
-        # Sort by frequency and get top 10
-        predecessors = []
+        appearance_dates = list(
+            NumberFrequencyStats.objects.filter(
+                number=number,
+                date__lte=analysis_date
+            ).values_list('date', flat=True)
+        )
+
+        if not appearance_dates:
+            return []
+
+        previous_dates = [d - timedelta(days=1) for d in appearance_dates]
         total_opportunities = len(appearance_dates)
-        
-        for pred_number, count in sorted(predecessor_counts.items(), key=lambda x: x[1], reverse=True)[:10]:
-            percentage = (count / total_opportunities * 100) if total_opportunities > 0 else 0
-            
-            predecessors.append({
-                'number': pred_number,
-                'occurrences': count,
-                'percentage': round(percentage, 2)
-            })
-        
+
+        predecessor_qs = (
+            NumberFrequencyStats.objects.filter(date__in=previous_dates)
+            .values('number')
+            .annotate(occurrences=Count('id'))
+            .order_by('-occurrences')[:10]
+        )
+
+        predecessors = [
+            {
+                'number': item['number'],
+                'occurrences': item['occurrences'],
+                'percentage': round(item['occurrences'] / total_opportunities * 100, 2)
+            }
+            for item in predecessor_qs
+        ]
+
         return predecessors
     
     def _calculate_prediction_probabilities(self, analysis_data: Dict, frequency_data) -> Dict[str, float]:

--- a/results/tests/test_frequency_analysis_service.py
+++ b/results/tests/test_frequency_analysis_service.py
@@ -1,0 +1,49 @@
+from datetime import date, timedelta
+from django.test import TestCase
+from results.models import NumberFrequencyStats
+from results.services.frequency_analysis_service import FrequencyAnalysisService
+
+
+class FrequencyAnalysisServiceQueryTests(TestCase):
+    def setUp(self):
+        self.service = FrequencyAnalysisService()
+
+        def add_stat(number, d):
+            NumberFrequencyStats.objects.create(
+                number=number,
+                date=d,
+                appeared_in_special=False,
+                appeared_in_first=False,
+                appeared_in_other=True,
+                day_of_week=d.weekday(),
+                day_of_month=d.day,
+                week_of_month=(d.day - 1) // 7 + 1,
+                month=d.month,
+                year=d.year,
+            )
+
+        d1 = date(2024, 1, 1)
+        add_stat('01', d1)
+        add_stat('02', d1)
+        add_stat('03', d1)
+        d2 = date(2024, 1, 3)
+        add_stat('01', d2)
+        add_stat('02', d2)
+        add_stat('04', d2)
+        add_stat('05', d1 - timedelta(days=1))
+        add_stat('06', date(2024, 1, 2))
+        add_stat('02', date(2024, 1, 2))
+
+    def test_companion_numbers_queries(self):
+        with self.assertNumQueries(2):
+            companions = self.service._calculate_companion_numbers('01', date(2024, 1, 3))
+        result = {c['number']: c['co_occurrences'] for c in companions}
+        self.assertEqual(result.get('02'), 2)
+
+    def test_predecessor_analysis_queries(self):
+        with self.assertNumQueries(2):
+            preds = self.service._calculate_predecessor_analysis('01', date(2024, 1, 3))
+        result = {p['number']: p['occurrences'] for p in preds}
+        self.assertEqual(result.get('05'), 1)
+        self.assertEqual(result.get('06'), 1)
+        self.assertEqual(result.get('02'), 1)


### PR DESCRIPTION
## Summary
- optimize companion and predecessor analysis to use grouped queries
- add DB index on NumberFrequencyStats.date
- add tests ensuring query counts remain low

## Testing
- `pytest results/tests/test_frequency_analysis_service.py -q` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68ae744a17988329975a896b18d46855