### PR TITLE
refactor: configurable baseline for prediction probabilities

### DIFF
--- a/results/services/frequency_analysis_service.py
+++ b/results/services/frequency_analysis_service.py
@@ -4,6 +4,7 @@ Provides comprehensive statistical analysis for lottery numbers
 """
 import json
 import logging
+import os
 from collections import defaultdict, Counter
 from datetime import datetime, timedelta, date
 from typing import Dict, List, Tuple, Optional, Any
@@ -42,6 +43,10 @@ class FrequencyAnalysisService:
     
     def __init__(self):
         self.cache_validity_days = 1  # Cache validity period
+        try:
+            self.baseline_probability = float(os.getenv('PREDICTION_BASELINE', '1.0'))
+        except ValueError:
+            self.baseline_probability = 1.0
     
     def get_comprehensive_analysis(self, number: str, analysis_date: date = None) -> Dict[str, Any]:
         """
@@ -339,19 +344,20 @@ class FrequencyAnalysisService:
         
         gan_analysis = analysis_data['gan_analysis']
         cycle_analysis = analysis_data['cycle_analysis']
-        
+        baseline = self.baseline_probability
+
         # Probability based on average cycle
         if cycle_analysis['avg_cycle'] > 0:
             cycle_probability = max(0, 100 - (gan_analysis['current_gan_days'] / cycle_analysis['avg_cycle'] * 100))
         else:
-            cycle_probability = 50
-        
+            cycle_probability = baseline
+
         # Probability when approaching max gan
         if gan_analysis['max_gan_days'] > 0:
             max_gan_ratio = gan_analysis['current_gan_days'] / gan_analysis['max_gan_days']
             max_gan_probability = min(100, max_gan_ratio * 100)
         else:
-            max_gan_probability = 50
+            max_gan_probability = baseline
         
         # Combined probability (weighted average)
         combined_probability = (cycle_probability * 0.6 + max_gan_probability * 0.4)

--- a/test_prediction_probabilities.py
+++ b/test_prediction_probabilities.py
@@ -1,0 +1,38 @@
+import sys
+import types
+import datetime
+
+# Mock minimal Django modules required for import
+django = types.ModuleType('django')
+sys.modules['django'] = django
+sys.modules['django.db'] = types.ModuleType('django.db')
+sys.modules['django.db.models'] = types.SimpleNamespace(Q=None, Count=None, Max=None, Min=None)
+utils = types.ModuleType('django.utils')
+utils.timezone = types.SimpleNamespace(now=lambda: datetime.datetime.now())
+sys.modules['django.utils'] = utils
+sys.modules['django.utils.timezone'] = utils.timezone
+
+# Mock results.models dependencies
+results_models = types.ModuleType('results.models')
+results_models.NumberFrequencyStats = object
+results_models.NumberAnalysisCache = object
+results_models.NumberAnalysisDetail = object
+results_models.KetQuaXoSo = object
+sys.modules['results.models'] = results_models
+
+from results.services.frequency_analysis_service import FrequencyAnalysisService
+
+
+def test_returns_baseline_when_no_data(monkeypatch):
+    monkeypatch.setenv('PREDICTION_BASELINE', '2.5')
+    service = FrequencyAnalysisService()
+    analysis_data = {
+        'gan_analysis': {'current_gan_days': 0, 'max_gan_days': 0},
+        'cycle_analysis': {'avg_cycle': 0}
+    }
+    probabilities = service._calculate_prediction_probabilities(analysis_data, [])
+    assert probabilities == {
+        'cycle_based': 2.5,
+        'max_gan_based': 2.5,
+        'combined': 2.5
+    }


### PR DESCRIPTION
## Summary
- allow baseline probability for predictions to be configured via `PREDICTION_BASELINE` env var (default 1.0%)
- use baseline when cycle and gan stats are unavailable
- add unit test for baseline fallback

## Testing
- `pytest test_prediction_probabilities.py --noconftest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae7868ff088329a0fc20875ff789e0